### PR TITLE
Utilizando o id para o filtro por usuário

### DIFF
--- a/lib/fog/radosgw/requests/usage/get_usage.rb
+++ b/lib/fog/radosgw/requests/usage/get_usage.rb
@@ -13,16 +13,16 @@ module Fog
       class Real
         include Utils
 
-        def get_usage(access_key_id, options = {})
-          path = "admin/usage"
-          t_now = Fog::Time.now
+        def get_usage(id, options = {})
+          path        = "admin/usage"
+          t_now       = Fog::Time.now
           start_time  = sanitize_and_convert_time(options[:start_time] || t_now - 86400)
           end_time    = sanitize_and_convert_time(options[:end_time]   || t_now)
-
-          query = "?format=json&start=#{start_time}&end=#{end_time}"
-          params = { 
+          param_id    = id.nil? ? '' : "&uid=#{escape(id)}"
+          query       = "?format=json&start=#{start_time}&end=#{end_time}#{param_id}"
+          params      = {
             :method => 'GET',
-            :path => path,
+            :path   => path,
           }
 
           begin
@@ -44,7 +44,7 @@ module Fog
       class Mock
         include Utils
 
-        def get_usage(access_key, options = {})
+        def get_usage(id, options = {})
           Excon::Response.new.tap do |response|
             response.status = 200
             response.headers['Content-Type'] = 'application/json'

--- a/lib/fog/radosgw/version.rb
+++ b/lib/fog/radosgw/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Radosgw
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end


### PR DESCRIPTION
Conforme a documentação do [Ceph](http://docs.ceph.com/docs/master/radosgw/adminops/#get-usage) existe a possibilidade de passar o id do usuário como filtro.
Foi realizado a alteração para permitir que, uma vez passado o parâmetro ele seja utilizado no filtro.
